### PR TITLE
Remove redundant IntervalTimer include in ArduinoOS CMake

### DIFF
--- a/ATmega/ATmegaOs/CMakeLists.txt
+++ b/ATmega/ATmegaOs/CMakeLists.txt
@@ -32,7 +32,6 @@ if (${CMAKE_SYSTEM_NAME_LOWER} STREQUAL "arduino")
         "${FPRIME_FRAMEWORK_PATH}/Os/Baremetal/Task.cpp"
         "${FPRIME_FRAMEWORK_PATH}/Os/Baremetal/File.cpp"
         "${FPRIME_FRAMEWORK_PATH}/Os/Baremetal/FileSystem.cpp"
-        "${FPRIME_FRAMEWORK_PATH}/Os/Baremetal/IntervalTimer.cpp"
         "${FPRIME_FRAMEWORK_PATH}/Os/Baremetal/Mutex.cpp"
         # Non-OS based queue implementations
         "${FPRIME_FRAMEWORK_PATH}/Os/Pthreads/BufferQueueCommon.cpp"


### PR DESCRIPTION
In the ArduinoOS CMakeLists, a source file for `IntervalTimer.cpp` is currently included twice:
`"${FPRIME_FRAMEWORK_PATH}/Os/Baremetal/IntervalTimer.cpp"` and
`"${CMAKE_CURRENT_LIST_DIR}/Arduino/IntervalTimer.cpp"`

Given that these both appear within the Arduino deployment case, building an F' deployment for Arduino will result in "Multiple definition" errors for IntervalTimer related code.
```
<command-line>:0:0: note: this is the location of the previous definition
IntervalTimer.cpp.obj (symbol from plugin): In function `Os::IntervalTimer::~IntervalTimer()':
(.text+0x0): multiple definition of `Os::IntervalTimer::~IntervalTimer()'
IntervalTimerCommon.cpp.obj (symbol from plugin):(.text+0x0): first defined here
/opt/arduino-1.8.15/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: Disabling relaxation: it will not work with multiple definitions
IntervalTimer.cpp.obj (symbol from plugin): In function `Os::IntervalTimer::~IntervalTimer()':
(.text+0x0): multiple definition of `Os::IntervalTimer::~IntervalTimer()'
IntervalTimerCommon.cpp.obj (symbol from plugin):(.text+0x0): first defined here
IntervalTimer.cpp.obj (symbol from plugin): In function `Os::IntervalTimer::~IntervalTimer()':
(.text+0x0): multiple definition of `Os::IntervalTimer::~IntervalTimer()'
IntervalTimerCommon.cpp.obj (symbol from plugin):(.text+0x0): first defined here
IntervalTimer.cpp.obj (symbol from plugin): In function `Os::IntervalTimer::~IntervalTimer()':
(.text+0x0): multiple definition of `Os::IntervalTimer::IntervalTimer()'
IntervalTimerCommon.cpp.obj (symbol from plugin):(.text+0x0): first defined here
IntervalTimer.cpp.obj (symbol from plugin): In function `Os::IntervalTimer::~IntervalTimer()':
(.text+0x0): multiple definition of `Os::IntervalTimer::IntervalTimer()'
IntervalTimerCommon.cpp.obj (symbol from plugin):(.text+0x0): first defined here
```

To fix this, the "Os/Baremetal" version of the source file has been removed, leaving only the Arduino version (as this is for Arduino deployments). This change has been tested and removes the error from F' build steps.
